### PR TITLE
fix for hypertranscript not lighting up on play

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,8 +19,10 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <script src="https://labs.hyperaud.io/temp/hyperaudio-lite.js"></script>
-    <script src="https://labs.hyperaud.io/temp/hyperaudio-lite-wrapper.js"></script>
+    <!--<script src="https://labs.hyperaud.io/temp/hyperaudio-lite.js"></script>-->
+    <script src="https://rawgit.com/hyperaudio/hyperaudio-lite/master/js/hyperaudio-lite.js"></script>
+    <!--<script src="https://labs.hyperaud.io/temp/hyperaudio-lite-wrapper.js"></script>-->
+    <script src="https://rawgit.com/hyperaudio/hyperaudio-lite/master/js/hyperaudio-lite-wrapper.js"></script>
     <script src="https://labs.hyperaud.io/temp/imagefilters.js"></script>
     <script src="https://hyperaudio.github.io/sharect/sharect.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/velocity/1.5.0/velocity.js"></script>


### PR DESCRIPTION
Updating to the latest version of `hyperaudio-lite.js` and `hyperaudio-lite-wrapper.js` seems to have fixed the problem - (https://github.com/BadIdeaFactory/contextubot/issues/62)


