### PR TITLE
fix for hyperaudio loading on pages non required

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,7 +22,7 @@
     <!--<script src="https://labs.hyperaud.io/temp/hyperaudio-lite.js"></script>-->
     <script src="https://rawgit.com/hyperaudio/hyperaudio-lite/master/js/hyperaudio-lite.js"></script>
     <!--<script src="https://labs.hyperaud.io/temp/hyperaudio-lite-wrapper.js"></script>-->
-    <script src="https://rawgit.com/hyperaudio/hyperaudio-lite/master/js/hyperaudio-lite-wrapper.js"></script>
+    <!--<script src="https://labs.hyperaud.io/temp/hyperaudio-lite-init.js"></script>-->
     <script src="https://labs.hyperaud.io/temp/imagefilters.js"></script>
     <script src="https://hyperaudio.github.io/sharect/sharect.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/velocity/1.5.0/velocity.js"></script>

--- a/src/ComicView.js
+++ b/src/ComicView.js
@@ -125,8 +125,9 @@ class ComicView extends Component {
         });
 
         console.log(output);
-
-        this.splitMedia(output);
+        if (output.length > 0) {
+          this.splitMedia(output);
+        }
       });
     });
   }

--- a/src/TranscriptView.js
+++ b/src/TranscriptView.js
@@ -31,9 +31,13 @@ class TranscriptView extends Component {
         // This figure may or may not work on other clips.
         // I'm not sure how we get around this without aligning.
 
-        transData = this.srtToHypertranscript(data, 2800);
-        this.setState({ ht: transData });
-        window.hyperaudiolite.init('hypertranscript', 'video', false);
+        if (data) {
+          transData = this.srtToHypertranscript(data, 2800);
+          this.setState({ ht: transData });
+          window.hyperaudiolite.init('hypertranscript', 'video', false);
+        } else {
+          this.setState({ ht: 'no transcript associated with this video' });
+        }
       });
     });
   }


### PR DESCRIPTION
Fixed.

1. HA now only being called when needed.
2. comic view doesn't generate if there is no transcript.